### PR TITLE
Fix: Update Font Awesome CDN to version 6.5.2

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
     
     <!-- External CSS -->
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Playfair+Display:wght@400;500;600;700&display=swap" rel="stylesheet">
     
     <!-- Schema Markup -->


### PR DESCRIPTION
I've updated the Font Awesome CDN link in index.html from version 6.4.0 to 6.5.2. This change addresses issues where the Twitter icon (fa-x-twitter) in the footer and the 'results focused' icon (fa-target) on the process page were not displaying correctly due to being unavailable or problematic in the older Font Awesome version.